### PR TITLE
Changed EyeTrackers order, OSC is now on top.

### DIFF
--- a/dllmain.cpp
+++ b/dllmain.cpp
@@ -173,26 +173,26 @@ namespace {
         std::vector<std::function<std::unique_ptr<IEyeTracker>()>> eyeTrackers;
 
         // Initialize the eye tracker. We try in order from "strongest check" to "weakest check".
+        
+        // 1) VRChat OSC checks if Baballonia app is running using a mutex.
+        eyeTrackers.push_back(createVRChatOSCEyeTracker);
 
-        // 1) Omnicept uses a background service, it is not likely to be installed if the device is not used.
+        // 2) Omnicept uses a background service, it is not likely to be installed if the device is not used.
         eyeTrackers.push_back(createOmniceptEyeTracker);
 
-        // 2) Virtual Desktop driver for SteamVR shall only be loaded if the streamer app is opened.
+        // 3) Virtual Desktop driver for SteamVR shall only be loaded if the streamer app is opened.
         eyeTrackers.push_back(createVirtualDesktopEyeTracker);
 
-        // 3) PSVR2 Toolkit driver for SteamVR shall only be loaded if the toolkit is loaded.
+        // 4) PSVR2 Toolkit driver for SteamVR shall only be loaded if the toolkit is loaded.
         eyeTrackers.push_back(createPsvr2ToolkitEyeTracker);
 
-        // 4) Varjo only loads if Varjo Base is running.
+        // 5) Varjo only loads if Varjo Base is running.
         eyeTrackers.push_back(createVarjoEyeTracker);
 
         if (systemName[0] == 'S' && systemName[1] == 'L' && systemName[2] == ',') {
-            // 5) Steam Link doesn't have any check, so use the driver version property to detect whether we should
+            // 6) Steam Link doesn't have any check, so use the driver version property to detect whether we should
             // enable it.
             eyeTrackers.push_back(createSteamLinkEyeTracker);
-        } else {
-            // 6) If Steam Link is undetected, we fall back to OSC for use with Bigscreen and Project Babble solutions.
-            eyeTrackers.push_back(createVRChatOSCEyeTracker);
         }
 
         for (uint32_t i = 0; !eyeTracker && i < std::size(eyeTrackers); i++) {


### PR DESCRIPTION
Goes with the pull request in https://github.com/mbucchia/_ARCHIVE_OpenXR-Eye-Trackers/pull/5
Fixes an issue where while using Virtual Desktop and VRC OSC it always prefers Virtual Desktop as the eye tracking source.